### PR TITLE
Explicit fsspec AbstractFileSystem support

### DIFF
--- a/src/pydantic_cereal/_path_utils.py
+++ b/src/pydantic_cereal/_path_utils.py
@@ -5,9 +5,12 @@ from fsspec import AbstractFileSystem
 
 def ensure_empty_dir(fs: AbstractFileSystem, workdir: str) -> str:
     """Ensure the directory exists, but is empty."""
-    dir_contents = fs.listdir(workdir)
-    if len(dir_contents) > 0:
-        raise FileExistsError(f"Non-empty directory exists at {workdir!r}")
+    if fs.exists(workdir):
+        dir_contents = fs.listdir(workdir)
+        if len(dir_contents) > 0:
+            raise FileExistsError(f"Non-empty directory exists at {workdir!r}")
+    else:
+        fs.mkdir(workdir)
     return workdir
 
 

--- a/src/pydantic_cereal/_path_utils.py
+++ b/src/pydantic_cereal/_path_utils.py
@@ -1,19 +1,16 @@
 """Universal path utilities."""
 
-from os import PathLike
-from typing import Union
-
-from upath import UPath
+from fsspec import AbstractFileSystem
 
 
-def ensure_empty_dir(uri: Union[str, PathLike, UPath]) -> UPath:
+def ensure_empty_dir(fs: AbstractFileSystem, workdir: str) -> str:
     """Ensure the directory exists, but is empty."""
-    res = UPath(uri)
-    try:
-        next(res.rglob("*"))
-    except StopIteration:
-        pass
-    else:
-        raise FileExistsError(f"Non-empty directory exists at {uri!r}")
-    res.mkdir(parents=True, exist_ok=True)
-    return res
+    dir_contents = fs.listdir(workdir)
+    if len(dir_contents) > 0:
+        raise FileExistsError(f"Non-empty directory exists at {workdir!r}")
+    return workdir
+
+
+def append_filename(fs: AbstractFileSystem, path: str, filename: str) -> str:
+    """Append filename to a path given filesystem."""
+    return path + fs.sep + filename

--- a/src/pydantic_cereal/examples/ex_pd.py
+++ b/src/pydantic_cereal/examples/ex_pd.py
@@ -1,13 +1,17 @@
 """Pandas example."""
 
 import pandas as pd
+from fsspec import AbstractFileSystem
 
 
-def pd_write(obj: pd.DataFrame, uri: str) -> None:
+def pd_write(obj: pd.DataFrame, fs: AbstractFileSystem, path: str) -> None:
     """Write Pandas dataframe to URI."""
-    obj.to_parquet(uri)
+    with fs.open(path, "wb") as f:
+        obj.to_parquet(f)
 
 
-def pd_read(uri: str) -> pd.DataFrame:
+def pd_read(fs: AbstractFileSystem, path: str) -> pd.DataFrame:
     """Read Pandas dataframe from URI."""
-    return pd.read_parquet(uri)
+    with fs.open(path, "rb") as f:
+        obj = pd.read_parquet(f)
+    return obj

--- a/src/pydantic_cereal/main.py
+++ b/src/pydantic_cereal/main.py
@@ -7,6 +7,7 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any, List, Optional, Tuple, Type, TypeVar, Union
 
+from fsspec import AbstractFileSystem, get_fs_token_paths
 from pydantic import (
     BaseModel,
     SerializerFunctionWrapHandler,
@@ -22,7 +23,7 @@ from typing_extensions import Annotated, Self
 from upath import UPath
 
 from ._metadata import CerealInfo, ImportString, cereal_meta_schema
-from ._path_utils import ensure_empty_dir
+from ._path_utils import append_filename, ensure_empty_dir
 from ._protocols import (
     CerealReader,
     CerealWriter,
@@ -48,15 +49,42 @@ class CerealContext(AbstractContextManager):
     This is managed by the [`Cereal`][pydantic_cereal.Cereal] class - users shouldn't use this directly!
     """
 
-    def __init__(self, cereal: "Cereal", workdir: Union[UPath, Path, str]) -> None:
+    def __init__(
+        self,
+        cereal: "Cereal",
+        target_path: Union[UPath, Path, str],
+        fs: Optional[AbstractFileSystem] = None,
+    ) -> None:
         assert isinstance(cereal, Cereal)
-        self._workdir = UPath(workdir)
+        if fs:
+            assert isinstance(target_path, str)
+            self._fs = fs
+        else:
+            if isinstance(target_path, str):
+                fs, _, paths = get_fs_token_paths(target_path)
+                inner_path = paths[-1]
+            elif isinstance(target_path, Path) and not isinstance(target_path, UPath):
+                fs, _, paths = get_fs_token_paths(f"file:{target_path}")
+                inner_path = paths[-1]
+            elif isinstance(target_path, UPath):
+                fs = target_path.fs
+                inner_path = target_path.path
+            else:
+                raise TypeError("'target_path' must be a 'str', 'Path' or 'UPath'")
+
+        self._target_path = inner_path
+        self._fs = fs
         self._cereal = cereal
 
     @property
-    def workdir(self) -> UPath:
-        """Working directory."""
-        return self._workdir
+    def target_path(self) -> UPath:
+        """Target path of context."""
+        return self._target_path
+
+    @property
+    def fs(self) -> AbstractFileSystem:
+        """File system to be used for target path."""
+        return self._fs
 
     @property
     def cereal(self) -> "Cereal":
@@ -168,7 +196,12 @@ class Cereal(object):
 
     # I/O API
 
-    def write_model(self, model: BaseModel, workdir: Union[UPath, Path, str]) -> UPath:
+    def write_model(
+        self,
+        model: BaseModel,
+        target_path: Union[UPath, Path, str],
+        fs: Optional[AbstractFileSystem] = None,
+    ) -> UPath:
         """Write the pydantic.BaseModel to the path.
 
         TODO
@@ -176,9 +209,10 @@ class Cereal(object):
         - Add JSON options.
         - Write YAML metadata instead?
         """
-        with self.context(workdir=workdir):
+        with self.context(target_path=target_path, fs=fs):
             # Create saving directory
-            wd = ensure_empty_dir(self.workdir)
+            fs = self.fs
+            wd = ensure_empty_dir(fs, self.workdir)
 
             # Write model (as JSON) with extra 'class' keyword
             # NOTE: This will write all wrapped types too!
@@ -187,18 +221,19 @@ class Cereal(object):
                 raise ValueError("Key 'class' is reserved for pydantic-cereal.")
             model_dict["class"] = get_import_string(type(model))
             model_json = json.dumps(model_dict, indent=2)
-            with (wd / "model.json").open(mode="w") as f:
+            with fs.open(append_filename(fs, wd, "model.json"), mode="w") as f:
                 f.write(model_json)
             # Write schema (as JSON)
             model_j_schema = json.dumps(model.model_json_schema(), indent=2)
-            with (wd / "model.schema.json").open(mode="w") as f:
+            with fs.open(append_filename(fs, wd, "model.schema.json"), mode="w") as f:
                 f.write(model_j_schema)
             # FIXME: We need to also write metadata somewhere, such as "what object is this?"...
         return wd
 
     def read_model(
         self,
-        workdir: Union[UPath, Path, str],
+        target_path: Union[UPath, Path, str],
+        fs: Optional[AbstractFileSystem] = None,
         *,
         supercls: Type[TModel] = BaseModel,  # type: ignore
     ) -> TModel:
@@ -207,10 +242,11 @@ class Cereal(object):
             raise TypeError(
                 f"Can only read Pydantic models, but {supercls!r} is not derived from BaseModel."
             )
-        with self.context(workdir=workdir):
+        with self.context(target_path=target_path, fs=fs):
+            fs = self.fs
             wd = self.workdir
             # Load raw data
-            with (wd / "model.json").open(mode="r") as f:
+            with fs.open(append_filename(fs, wd, "model.json"), mode="r") as f:
                 model_raw = json.load(f)
             # Get model class
             assert isinstance(model_raw, dict)
@@ -234,9 +270,11 @@ class Cereal(object):
 
     # Internal API
 
-    def context(self, workdir: Union[UPath, Path, str]) -> CerealContext:
+    def context(
+        self, target_path: Union[UPath, Path, str], fs: Optional[AbstractFileSystem]
+    ) -> CerealContext:
         """Create a writing context (usable via `with` statement)."""
-        return CerealContext(self, workdir=workdir)
+        return CerealContext(self, target_path=target_path, fs=fs)
 
     @property
     def active_context(self) -> Optional[CerealContext]:
@@ -258,11 +296,18 @@ class Cereal(object):
         self._context_stack.pop()
 
     @property
-    def workdir(self) -> UPath:
+    def fs(self) -> AbstractFileSystem:
+        """Current filesystem."""
+        if self.active_context is None:
+            raise CerealContextError("No context is active - no current filesystem.")
+        return self.active_context.fs
+
+    @property
+    def workdir(self) -> str:
         """Working directory."""
         if self.active_context is None:
             raise CerealContextError("No context is active - no working directory.")
-        return self.active_context.workdir
+        return self.active_context.target_path
 
     def _generate_filename(self, obj: Any) -> str:
         """Generate a file name for an object.
@@ -279,15 +324,18 @@ class Cereal(object):
             raise CerealContextError("Context not active - aborting write.")
         filename = self._generate_filename(obj)
 
-        write_path = self.workdir / filename
-        writer(obj, str(write_path))
+        fs = self.fs
+        write_path = append_filename(fs, self.workdir, filename)
+        writer(obj, self.fs, write_path)
         return filename
 
     def _load_from_meta(self, cereal_meta: CerealInfo) -> Any:
         """Load an object from metadata."""
         f_reader, _ = self._normalize_reader(cereal_meta.cereal_reader)
-        upath = self.workdir / cereal_meta.object_path
-        return f_reader(str(upath))
+
+        fs = self.fs
+        path = append_filename(fs, self.workdir, cereal_meta.object_path)
+        return f_reader(fs, path)
 
     # Helpers
 

--- a/src/pydantic_cereal/main.py
+++ b/src/pydantic_cereal/main.py
@@ -58,7 +58,7 @@ class CerealContext(AbstractContextManager):
         assert isinstance(cereal, Cereal)
         if fs:
             assert isinstance(target_path, str)
-            self._fs = fs
+            inner_path = target_path
         else:
             if isinstance(target_path, str):
                 fs, _, paths = get_fs_token_paths(target_path)

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
+from fsspec import get_fs_token_paths
+from fsspec.implementations.local import LocalFileSystem
+from fsspec.implementations.memory import MemoryFileSystem
 from pytest_lazyfixture import lazy_fixture
 
 from pydantic_cereal import Cereal
@@ -13,6 +16,12 @@ from pydantic_cereal import Cereal
 def random_path() -> str:
     """Generate a random path."""
     return str(uuid4()).replace("-", "")
+
+
+@pytest.fixture
+def random_path_in_localdir(tmp_path: str, random_path: str) -> str:
+    """Get path to a randomly generated directory in temporary directory."""
+    return f"{tmp_path}/{random_path}"
 
 
 @pytest.fixture
@@ -37,6 +46,20 @@ def uri_localdir(tmp_path: Path, random_path: str) -> str:
 def uri(request: pytest.FixtureRequest) -> str:
     """Fixture for URI for different filesystems."""
     return str(request.param)
+
+
+@pytest.fixture
+def fs_memory() -> MemoryFileSystem:
+    """MemoryFileSystem at root of memory."""
+    fs, _, _ = get_fs_token_paths("memory://")
+    return fs
+
+
+@pytest.fixture
+def fs_localdir(tmp_path: Path) -> LocalFileSystem:
+    """LocalFileSystem in temporary directory."""
+    fs, _, _ = get_fs_token_paths("file://")
+    return fs
 
 
 @pytest.fixture

--- a/src/tests/test_readme.py
+++ b/src/tests/test_readme.py
@@ -3,8 +3,8 @@
 The "global" `cereal` object here is only global to this module, which
 """
 
+from fsspec import AbstractFileSystem
 from pydantic import BaseModel, ConfigDict
-from upath import UPath  # based on `fsspec`, used for `pathlib.Path`-like interface
 
 from pydantic_cereal import Cereal
 
@@ -26,14 +26,14 @@ class MyType(object):
 # Create reader and writer from an fsspec URI
 
 
-def my_reader(uri: str) -> MyType:
+def my_reader(fs: AbstractFileSystem, path: str) -> MyType:
     """Read a MyType from an fsspec URI."""
-    return MyType(value=UPath(uri).read_text())
+    return MyType(value=fs.read_text(path))
 
 
-def my_writer(obj: MyType, uri: str) -> None:
+def my_writer(obj: MyType, fs: AbstractFileSystem, path: str) -> None:
     """Write a MyType object to an fsspec URI."""
-    UPath(uri).write_text(obj.value)
+    fs.write_text(path, obj.value)
 
 
 # "Register" this type with pydantic-cereal


### PR DESCRIPTION
- Now Reader/Writer functions are forced to explicitly use an `fsspec` `AbstractFileSystem` and path within that filesystem
- The library now doesn't rely on UPath internally, but still accepts it as a path to `write_model`/`read_model`. Instead, it store the filesystem object and path within it separately