### PR TITLE
Update documentation after fsspec rewrite

### DIFF
--- a/docs/examples/minimal.ipynb
+++ b/docs/examples/minimal.ipynb
@@ -21,10 +21,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"Minimal imports.\"\"\"\n",
+    "\"\"\"Minimal imports to get started.\"\"\"\n",
     "\n",
-    "from typing import NewType\n",
-    "from upath import UPath\n",
+    "from fsspec import AbstractFileSystem\n",
     "from pydantic import BaseModel, ConfigDict\n",
     "from pydantic_cereal import Cereal\n",
     "\n",
@@ -35,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have a custom type `MyType`, in this case it's just an alias for `str`:"
+    "We have a custom type `MyType`, in this case it's just an wrapper for a `str`:"
    ]
   },
   {
@@ -44,7 +43,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "MyType = NewType(\"MyType\", str)  # actually `str`, but type checker has special semantics "
+    "class MyType(object):\n",
+    "    \"\"\"My custom type, which isn't a Pydantic model.\"\"\"\n",
+    "\n",
+    "    def __init__(self, value: str):\n",
+    "        \"\"\"Initialize the object.\"\"\"\n",
+    "        self.value = str(value)\n",
+    "\n",
+    "    def __repr__(self) -> str:\n",
+    "        \"\"\"Represent the string.\"\"\"\n",
+    "        return f\"MyType({self.value})\"\n",
+    "\n",
+    "    def __str__(self) -> str:\n",
+    "        \"\"\"Return the internal string.\"\"\"\n",
+    "        return str(self.value)"
    ]
   },
   {
@@ -52,7 +64,8 @@
    "metadata": {},
    "source": [
     "We must add reader and writer classes for it. \n",
-    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) URIs as inputs.\n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) file system\n",
+    "and path (within that filesystem) as inputs.\n",
     "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
    ]
   },
@@ -62,13 +75,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def my_reader(uri: str) -> MyType:\n",
-    "    \"\"\"Read the object from an fsspec URI.\"\"\"\n",
-    "    return MyType(UPath(uri).read_text())\n",
+    "def my_reader(fs: AbstractFileSystem, path: str) -> MyType:\n",
+    "    \"\"\"Read a MyType from an fsspec URI.\"\"\"\n",
+    "    res = fs.read_text(path)\n",
+    "    if isinstance(res, bytes):\n",
+    "        res = res.decode(\"utf8\")\n",
+    "    else:\n",
+    "        res = str(res)\n",
+    "    return MyType(value=res)\n",
     "\n",
-    "def my_writer(obj: MyType, uri: str) -> None:\n",
-    "    \"\"\"Write the object to an fsspec URI.\"\"\"\n",
-    "    UPath(uri).write_text(obj)\n",
+    "\n",
+    "def my_writer(obj: MyType, fs: AbstractFileSystem, path: str) -> None:\n",
+    "    \"\"\"Write a MyType object to an fsspec URI.\"\"\"\n",
+    "    fs.write_text(path, obj.value)\n",
+    "\n",
     "\n",
     "MyWrappedType = cereal.wrap_type(MyType, reader=my_reader, writer=my_writer)"
    ]
@@ -145,7 +165,7 @@
     {
      "data": {
       "text/plain": [
-       "MemoryPath('memory://example_model/')"
+       "'/example_model'"
       ]
      },
      "execution_count": 7,
@@ -172,7 +192,7 @@
     {
      "data": {
       "text/plain": [
-       "'my_field'"
+       "MyType(my_field)"
       ]
      },
      "execution_count": 8,
@@ -201,7 +221,7 @@
     {
      "data": {
       "text/plain": [
-       "'my_field'"
+       "MyType(my_field)"
       ]
      },
      "execution_count": 9,
@@ -224,22 +244,40 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fsspec.implementations.memory import MemoryFileSystem  # noqa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = MemoryFileSystem()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[MemoryPath('memory://example_model/51c07fc879fa403993ba780d9ff29b52'),\n",
-       " MemoryPath('memory://example_model/model.json'),\n",
-       " MemoryPath('memory://example_model/model.schema.json')]"
+       "['/example_model/9048f517f71f434aad4a5481f3b2b3d4',\n",
+       " '/example_model/model.json',\n",
+       " '/example_model/model.schema.json']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "list(UPath(\"memory://example_model\").glob(\"*\"))"
+    "fs.glob(\"example_model/*\")"
    ]
   },
   {

--- a/docs/examples/pandas.ipynb
+++ b/docs/examples/pandas.ipynb
@@ -104,7 +104,7 @@
     {
      "data": {
       "text/plain": [
-       "MemoryPath('memory://example_model/')"
+       "'/example_model'"
       ]
      },
      "execution_count": 5,
@@ -273,24 +273,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fsspec.implementations.memory import MemoryFileSystem  # noqa\n",
+    "\n",
+    "fs = MemoryFileSystem()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[MemoryPath('memory://example_model/example_model'),\n",
-       " MemoryPath('memory://example_model/model.json'),\n",
-       " MemoryPath('memory://example_model/model.schema.json')]"
+       "['/example_model/3f084fb6b6024e8da54fb231e655c8ea',\n",
+       " '/example_model/model.json',\n",
+       " '/example_model/model.schema.json']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "list(UPath(\"memory://example_model\").glob(\"*\"))"
+    "fs.glob(\"example_model/*\")"
    ]
   },
   {

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,13 +10,16 @@ brings many changes and improvements, including a
 
 This package, `pydantic-cereal`, is a small extension package that enables users to serialize Pydantic
 models with "arbitrary" (non-JSON-fiendly) types to "arbitrary" file-system-like locations.
-It uses [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) and
-[`universal_pathlib`](https://pypi.org/project/universal-pathlib/) to support generic file systems.
+It uses [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) to support generic file systems.
 Writing a custom writer (serializer) and reader (loader) with `fsspec` URIs is quite straightforward.
 
-## Usage Example
+You can also use [`universal-pathlib`](https://pypi.org/project/universal-pathlib/)'s
+`UPath` with `pydantic-cereal`.
 
-For most uses, you only need the [`Cereal`][pydantic_cereal.Cereal] class and `fsspec` or `upath`.
+## Usage Examples
+
+See the [minimal pure-Python example](./examples/minimal.ipynb) to learn how to wrap your own type.
+Below is a preview of this example.
 
 ```python
 from fsspec import AbstractFileSystem
@@ -27,6 +30,8 @@ from pydantic_cereal import Cereal
 cereal = Cereal()  # This is a global variable
 
 
+# Create and "register" a custom type
+
 class MyType(object):
     """My custom type, which isn't a Pydantic model."""
 
@@ -35,14 +40,6 @@ class MyType(object):
 
     def __repr__(self) -> str:
         return f"MyType({self.value})"
-```
-
-!!! warning
-
-    There are some [limitations][limitations] on where you can define your Pydantic models.
-
-```python
-# Create reader and writer from an fsspec filesystem and path
 
 
 def my_reader(fs: AbstractFileSystem, path: str) -> MyType:
@@ -54,13 +51,10 @@ def my_writer(obj: MyType, fs: AbstractFileSystem, path: str) -> None:
     """Write a MyType object to an fsspec URI."""
     fs.write_text(path, obj.value)
 
-
-# "Register" this type with pydantic-cereal
 MyWrappedType = cereal.wrap_type(MyType, reader=my_reader, writer=my_writer)
-# NOTE: Your type isn't modified, we just apply `Annotated` with a custom serializer and validator
 
 
-# Use the wrapped type as the fields of your Pydantic model
+# Use type within Pydantic model
 
 class MyModel(BaseModel):
     """My custom Pydantic model."""
@@ -81,8 +75,35 @@ assert isinstance(obj, MyModel)
 assert isinstance(obj.fld, MyType)
 ```
 
-For more detailed discussion, see the [minimal pure-Python example](./examples/minimal.ipynb) or
-the [Pandas dataframe example](./examples/pandas.ipynb)
+For wrapping 3rd-party libraries, see the [Pandas dataframe example](./examples/pandas.ipynb).
+
+## Key Concepts
+
+The [`Cereal`][pydantic_cereal.Cereal] class is the main interface, handling type registration and I/O.
+You should define one global object of this type, i.e. `cereal = Cereal()` within your modules.
+
+You can save or load Pydantic models via `cereal` to any `fsspec` URI, `universal-pathlib` `UPath` or -
+for more complicated cases - to a path within a pre-made `fsspec` file system.
+The serialization format is a *directory* under the given path, containing the `model.json` (main fields
+and metadata), `model.schema.json` (JSON schema for your Pydantic model, as a nice-to-have) and
+the serialized objects that are *not* representable in JSON.
+
+In order for `cereal` and `Pydantic` to know how to serialize your non-JSON-compatible type, you must:
+
+1. wrap your type with [`cereal.wrap_type(type, reader, writer)`][pydantic_cereal.Cereal.wrap_type];
+2. specify[`arbitrary_types_allowed`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.arbitrary_types_allowed)
+   in your [Pydantic model configuration](https://docs.pydantic.dev/latest/concepts/config/);
+3. add the *wrapped* type as fields in your Pydantic model;
+4. use [`cereal.write_model(mdl, path)`][pydantic_cereal.Cereal.write_model] to write your model object
+   to the given fsspec path.
+
+!!! note
+
+    You can easily wrap types from 3rd-party classes. Since you don't need to re-define the type, it will
+    "just work" outside of the Pydantic models.
+
+    You can even specify different serialization mechanisms for different fields that have the same type;
+    just wrap your types multiple times with different readers/writers.
 
 ## How It Works
 
@@ -92,13 +113,27 @@ that are available in Pydantic V2 and use
 [`typing.Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated)
 (or `typing_extensions.Annotated`).
 
+!!! note
+
+    When you use `wrap_type`, the only "wrapping" done is adding metadata via
+    [`typing.Annotated`](https://docs.python.org/3/library/typing.html#typing.Annotated).
+    The class itself isn't changed, and nothing will change in terms of your code, IDE or type checkers!
+
 The [`Cereal`][pydantic_cereal.Cereal] class uses a context to convert the objects-to-write into
-JSON-compatible metadata, and call the `writer` function.
+JSON-compatible metadata, then call the respective `writer`
+([`CerealWriter`-compatible][pydantic_cereal.CerealWriter]) functions.
+
+When reading, the `Cereal` object imports your Pydantic model class and any `reader`
+([`CerealReader`-compatible][pydantic_cereal.CerealReader]) functions for your wrapped types,
+then reads the objects from the `fsspec` URIs, and plugs them into your model.
 
 ## Limitations
 
 1. Your `cereal` object doesn't necessarily have to be a global, but the same instance must be
-   used to both *register* your model type and *write*/*read* your object.
-2. You can't define your Pydantic model inside a function, because `pydantic-cereal` relies on
-   importing your type, and we can't import local variables.
+   used to both *register* your model type and *write* your object (and ideally *read* too).
+2. You can't define your types or Pydantic model inside a function, because `pydantic-cereal` relies on
+   importing your type by dotted name (`package.module.MyType`), and we can't import local variables.
    Instead, define it in a top-level module, then import it.
+3. When running from the REPL or in a Jupyter notebook, the module name for your class definitions
+   will be `__main__`. This means your saved objects will only be loadable in the same kind of session.
+   We strongly recommend you move your code to a *Python package* structure ASAP to avoid issues.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,6 @@ This package, `pydantic-cereal`, is a small extension package that enables users
 models with "arbitrary" (non-JSON-fiendly) types to "arbitrary" file-system-like locations.
 It uses [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) to support generic file systems.
 Writing a custom writer (serializer) and reader (loader) with `fsspec` URIs is quite straightforward.
-
 You can also use [`universal-pathlib`](https://pypi.org/project/universal-pathlib/)'s
 `UPath` with `pydantic-cereal`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,6 +8,12 @@ This reference contains automatically generated Python API docs.
 
 ::: pydantic_cereal.cereal_meta_schema
 
+<!-- Protocols -->
+
+::: pydantic_cereal.CerealReader
+
+::: pydantic_cereal.CerealWriter
+
 <!-- Errors -->
 
 ::: pydantic_cereal.CerealBaseError

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,10 @@ plugins:
               - "!^_" # exlude all members starting with _
   - mkdocs-jupyter:
       include_source: true
-      execute: true # TODO: Actually, we want to re-execute these, but not right now
+      execute: true
+      allow_errors: false # Enforce up-to-date documentation
+      # kernel_name: python3
+      # ignore_h1_titles: true
 
 markdown_extensions:
   - admonition

--- a/src/pydantic_cereal/__init__.py
+++ b/src/pydantic_cereal/__init__.py
@@ -6,6 +6,8 @@ __all__ = [
     "CerealProtocolError",
     "CerealRegistrationError",
     "Cereal",
+    "CerealReader",
+    "CerealWriter",
     "cereal_meta_schema",
     "__version__",
 ]
@@ -16,5 +18,5 @@ from .errors import (
     CerealProtocolError,
     CerealRegistrationError,
 )
-from .main import Cereal, cereal_meta_schema
+from .main import Cereal, CerealReader, CerealWriter, cereal_meta_schema
 from .version import __version__

--- a/src/pydantic_cereal/examples/ex_pd.py
+++ b/src/pydantic_cereal/examples/ex_pd.py
@@ -6,12 +6,12 @@ from fsspec import AbstractFileSystem
 
 def pd_write(obj: pd.DataFrame, fs: AbstractFileSystem, path: str) -> None:
     """Write Pandas dataframe (as Parquet) to a path within a filesystem."""
-    with fs.open(path, "wb") as f:
-        obj.to_parquet(f)
+    with fs.open(path, mode="wb") as f:
+        obj.to_parquet(f)  # type: ignore
 
 
 def pd_read(fs: AbstractFileSystem, path: str) -> pd.DataFrame:
     """Read Pandas dataframe (as Parquet) from a path within a filesystem."""
-    with fs.open(path, "rb") as f:
-        obj = pd.read_parquet(f)
+    with fs.open(path, mode="rb") as f:
+        obj = pd.read_parquet(f)  # type: ignore
     return obj

--- a/src/pydantic_cereal/main.py
+++ b/src/pydantic_cereal/main.py
@@ -40,7 +40,7 @@ T = TypeVar("T")
 TModel = TypeVar("TModel", bound=BaseModel)
 
 
-__all__ = ["Cereal"]
+__all__ = ["Cereal", "CerealReader", "CerealWriter", "cereal_meta_schema"]
 
 
 class CerealContext(AbstractContextManager):

--- a/src/tests/test_readme.py
+++ b/src/tests/test_readme.py
@@ -23,7 +23,7 @@ class MyType(object):
         return f"MyType({self.value})"
 
 
-# Create reader and writer from an fsspec URI
+# Create reader and writer from an fsspec filesystem and path
 
 
 def my_reader(fs: AbstractFileSystem, path: str) -> MyType:


### PR DESCRIPTION
Updated documentation, including example notebooks.

Added `CerealReader` and `CerealWriter` protocols to public API (to help with typing).