### PR TITLE
Add Polars dataframe examples and tests

### DIFF
--- a/docs/examples/pandas.ipynb
+++ b/docs/examples/pandas.ipynb
@@ -37,7 +37,8 @@
    "metadata": {},
    "source": [
     "We must add reader and writer classes for it. \n",
-    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) `AbstractFileSystem` and string `path` as inputs.\n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) file system\n",
+    "and path (within that filesystem) as inputs.\n",
     "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
    ]
   },

--- a/docs/examples/pandas.ipynb
+++ b/docs/examples/pandas.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "source": [
     "We must add reader and writer classes for it. \n",
-    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) URIs as inputs.\n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) `AbstractFileSystem` and string `path` as inputs.\n",
     "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
    ]
   },

--- a/docs/examples/polars.ipynb
+++ b/docs/examples/polars.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "source": [
     "We must add reader and writer classes for it. \n",
-    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) URIs as inputs.\n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) `AbstractFileSystem` and string `path` as inputs.\n",
     "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
    ]
   },

--- a/docs/examples/polars.ipynb
+++ b/docs/examples/polars.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Polars Usage Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This provides an minimal usage example for `pydantic-cereal` with Polars.\n",
+    "To start, use the following imports and create a global `cereal` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"Minimal imports.\"\"\"\n",
+    "\n",
+    "import polars as pl\n",
+    "from pydantic import BaseModel, ConfigDict\n",
+    "from pydantic_cereal import Cereal\n",
+    "from pydantic_cereal.examples.ex_pl import pl_read, pl_write\n",
+    "\n",
+    "cereal = Cereal()  # global variable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We must add reader and writer classes for it. \n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) URIs as inputs.\n",
+    "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MyDF = cereal.wrap_type(pl.DataFrame, reader=pl_read, writer=pl_write)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use this type in a Pydantic model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ExampleModel(BaseModel):\n",
+    "    \"\"\"Example model.\"\"\"\n",
+    "\n",
+    "    model_config = ConfigDict(arbitrary_types_allowed=True)\n",
+    "\n",
+    "    df: MyDF  # NOTE: Make sure to use the wrapped type!\n",
+    "    value: str = \"default_value\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can instantiate objects as usual:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdl = ExampleModel(df=pl.DataFrame({\"foo\": [\"a\", \"b\", \"c\"], \"bar\": [1, 2, 3]}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, you can write your model to an arbitrary directory-like `fsspec` URI.\n",
+    "In this example, we're writing to a temporary [`MemoryFileSystem`](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.implementations.memory.MemoryFileSystem):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/example_model'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cereal.write_model(mdl, \"memory://example_model\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can load another object from there:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>foo</th><th>bar</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>1</td></tr><tr><td>&quot;b&quot;</td><td>2</td></tr><tr><td>&quot;c&quot;</td><td>3</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 2)\n",
+       "┌─────┬─────┐\n",
+       "│ foo ┆ bar │\n",
+       "│ --- ┆ --- │\n",
+       "│ str ┆ i64 │\n",
+       "╞═════╪═════╡\n",
+       "│ a   ┆ 1   │\n",
+       "│ b   ┆ 2   │\n",
+       "│ c   ┆ 3   │\n",
+       "└─────┴─────┘"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "obj = cereal.read_model(\"memory://example_model\")\n",
+    "assert isinstance(obj, ExampleModel)\n",
+    "obj.df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you require a specific type (or base type), you can specify this in `read_model`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (3, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>foo</th><th>bar</th></tr><tr><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;a&quot;</td><td>1</td></tr><tr><td>&quot;b&quot;</td><td>2</td></tr><tr><td>&quot;c&quot;</td><td>3</td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "shape: (3, 2)\n",
+       "┌─────┬─────┐\n",
+       "│ foo ┆ bar │\n",
+       "│ --- ┆ --- │\n",
+       "│ str ┆ i64 │\n",
+       "╞═════╪═════╡\n",
+       "│ a   ┆ 1   │\n",
+       "│ b   ┆ 2   │\n",
+       "│ c   ┆ 3   │\n",
+       "└─────┴─────┘"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cereal.read_model(\"memory://example_model\", supercls=ExampleModel).df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Inspecting the path, you can see the file structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fsspec.implementations.memory import MemoryFileSystem  # noqa\n",
+    "\n",
+    "fs = MemoryFileSystem()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['/example_model/e0cb38c0b7ce46b1b36c70116b98ad0e',\n",
+       " '/example_model/model.json',\n",
+       " '/example_model/model.schema.json']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fs.glob(\"example_model/*\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pyd-cereal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/polars.ipynb
+++ b/docs/examples/polars.ipynb
@@ -36,7 +36,8 @@
    "metadata": {},
    "source": [
     "We must add reader and writer classes for it. \n",
-    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) `AbstractFileSystem` and string `path` as inputs.\n",
+    "These must accept [`fsspec`](https://filesystem-spec.readthedocs.io/en/latest/) file system\n",
+    "and path (within that filesystem) as inputs.\n",
     "We can register these with our `cereal` object by creating a wrapped (`Annotated`) type."
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ docs = [
     "mkdocs-jupyter==0.24.6",
     "pygments==2.17.2",
 ]
-datatests = ["pandas~=2.1.3", "pyarrow~=14.0.1", "pyspark~=3.5.0"]
+datatests = ["pandas~=2.1.3", "pyarrow~=14.0.1", "pyspark~=3.5.0", "polars~=0.20.7"]
 
 [project.scripts]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "ipykernel",
     # Stubs (including optional dependencies)
     "pandas-stubs",
+    "polars",
     # Additional dependencies for testing
     "gcsfs~=2023.12.2",
 ]

--- a/src/pydantic_cereal/examples/ex_pl.py
+++ b/src/pydantic_cereal/examples/ex_pl.py
@@ -1,0 +1,18 @@
+"""Polars example."""
+
+import polars as pl
+from fsspec import AbstractFileSystem
+
+
+def pl_write(obj: pl.DataFrame, fs: AbstractFileSystem, path: str) -> None:
+    """Write Pandas dataframe (as Parquet) to a path within a filesystem."""
+    with fs.open(path, mode="wb") as f:
+        obj.write_parquet(f)
+
+
+def pl_read(fs: AbstractFileSystem, path: str) -> pl.DataFrame:
+    """Read Pandas dataframe (as Parquet) from a path within a filesystem."""
+    with fs.open(path, mode="rb") as f:
+        # NOTE: There is some collision happening with polars when passing 'f' directly
+        obj = pl.read_parquet(f.read())
+    return obj

--- a/src/tests/def_polars.py
+++ b/src/tests/def_polars.py
@@ -1,0 +1,25 @@
+"""Define types with polars."""
+"""Test polars models."""
+
+# ruff: noqa: E402
+import polars as pl
+from pydantic import BaseModel, ConfigDict
+
+from pydantic_cereal.examples.ex_pl import pl_read, pl_write
+
+from .common import cereal
+
+PolarsDF = cereal.wrap_type(pl.DataFrame, pl_read, pl_write)
+
+
+class ModelWithPolars(BaseModel):
+    """Foo class."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    pldf: PolarsDF
+
+    def __eq__(self, rhs: object) -> bool:
+        """Check if objects are equal (since Polars dataframes don't support `==`)."""
+        if isinstance(rhs, ModelWithPolars):
+            return self.pldf.equals(rhs.pldf)
+        return NotImplemented

--- a/src/tests/def_polars.py
+++ b/src/tests/def_polars.py
@@ -1,5 +1,4 @@
-"""Define types with polars."""
-"""Test polars models."""
+"""Define types with polars, to be used for testing."""
 
 # ruff: noqa: E402
 import polars as pl

--- a/src/tests/test_roundtrip.py
+++ b/src/tests/test_roundtrip.py
@@ -43,7 +43,7 @@ class FileSystemTestCases:
             else:
                 token = None
 
-            raw_fs = gcsfs.GCSFileSystem(project=gcs_project, check_connection=True, token=token)
+            raw_fs = gcsfs.GCSFileSystem(project=gcs_project, token=token)
             raw_fs.ls(gcs_bucket)  # check if bucket is available
             fs = DirFileSystem(path=gcs_bucket, fs=raw_fs)
             return lambda: fs, lambda: fs
@@ -74,6 +74,14 @@ class CerealObjectTestCases:
 
         df = pd.DataFrame({"foo": [1, 2, 3]})
         mdl = ModelWithPandas(pdf=df)
+        return mdl
+
+    def case_polars_model(self) -> BaseModel:
+        """Case with a Polars model installed."""
+        from .def_polars import ModelWithPolars, pl
+
+        df = pl.DataFrame({"foo": [1, 2, 3]})
+        mdl = ModelWithPolars(pldf=df)
         return mdl
 
 


### PR DESCRIPTION
Changes made:
- Polars dataframe examples of read/writing to parquet files
- Updated markdowns in example notebooks
- Small deprecation cleanup with GCS test case